### PR TITLE
Update tag-input.component.ts

### DIFF
--- a/lib/tag-input/tag-input.component.ts
+++ b/lib/tag-input/tag-input.component.ts
@@ -206,7 +206,7 @@ export class TagInputComponent implements ControlValueAccessor, OnDestroy, OnIni
   }
 
   /** Implemented as part of ControlValueAccessor. */
-  onChange: (value) => any = () => { };
+  onChange: (value: any) => any = () => { };
 
   onTouched: () => any = () => { };
 


### PR DESCRIPTION
Fixed issue that would cause a `Parameter 'value' implicitly has an 'any' type.` error to be thrown