### PR TITLE
Check before calling unsubscribe in ngOnDestroy

### DIFF
--- a/lib/components/tag-input/tag-input.component.ts
+++ b/lib/components/tag-input/tag-input.component.ts
@@ -325,6 +325,8 @@ export class TagInputComponent implements ControlValueAccessor, OnDestroy, OnIni
   }
 
   ngOnDestroy() {
-    this.tagInputSubscription.unsubscribe();
+    if (this.tagInputSubscription) {
+      this.tagInputSubscription.unsubscribe();
+    }
   }
 }


### PR DESCRIPTION
Karma testing a component that uses <rl-tag-input> in it's template will cause the following error:

TypeError: Cannot read property 'unsubscribe' of undefined
        at TagInputComponent.ngOnDestroy (webpack:///~/angular2-tag-input/dist/lib/components/tag-input/tag-input.component.js:207:0 <- src/test.ts:94090:34)

Therefore I think it would make sense to check before unsubscribing.